### PR TITLE
Load pretrained models on different device

### DIFF
--- a/src/test.py
+++ b/src/test.py
@@ -110,7 +110,8 @@ if __name__ == '__main__':
     model = create_model(configs)
     print('\n\n' + '-*=' * 30 + '\n\n')
     assert os.path.isfile(configs.pretrained_path), "No file at {}".format(configs.pretrained_path)
-    model.load_state_dict(torch.load(configs.pretrained_path))
+    model.load_state_dict(torch.load(configs.pretrained_path, map_location=lambda storage, loc: storage))
+
     print('Loaded weights from {}\n'.format(configs.pretrained_path))
 
     configs.device = torch.device('cpu' if configs.no_cuda else 'cuda:{}'.format(configs.gpu_idx))


### PR DESCRIPTION
## Problem statement

The current code results in the following error when running `python test.py --gpu_idx 0 --peak_thresh 0.2`:
```
using ResNet architecture with feature pyramid


-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=-*=


Traceback (most recent call last):
  File "test.py", line 113, in <module>
    model.load_state_dict(torch.load(configs.pretrained_path))
  File "/usr/local/lib/python3.6/dist-packages/torch/serialization.py", line 593, in load
    return _legacy_load(opened_file, map_location, pickle_module, **pickle_load_args)
  File "/usr/local/lib/python3.6/dist-packages/torch/serialization.py", line 773, in _legacy_load
    result = unpickler.load()
  File "/usr/local/lib/python3.6/dist-packages/torch/serialization.py", line 729, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "/usr/local/lib/python3.6/dist-packages/torch/serialization.py", line 178, in default_restore_location
    result = fn(storage, location)
  File "/usr/local/lib/python3.6/dist-packages/torch/serialization.py", line 154, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "/usr/local/lib/python3.6/dist-packages/torch/serialization.py", line 148, in validate_cuda_device
    device=device, device_count=torch.cuda.device_count()))
RuntimeError: Attempting to deserialize object on CUDA device 1 but torch.cuda.device_count() is 1. Please use torch.load with map_location to map your storages to an existing device.
```

## Proposed solution

Remap the Tensor location at load time using the `map_location`.
