### PR TITLE
Ignore unknown argument in argparse

### DIFF
--- a/sfa/utils/demo_utils.py
+++ b/sfa/utils/demo_utils.py
@@ -56,7 +56,7 @@ def parse_demo_configs():
     parser.add_argument('--output-width', type=int, default=608,
                         help='the width of showing output, the height maybe vary')
 
-    configs = edict(vars(parser.parse_args()))
+    configs = edict(vars(parser.parse_known_args()[0]))
     configs.pin_memory = True
     configs.distributed = False  # For testing on 1 GPU only
 


### PR DESCRIPTION
Ignoring the unknown arguments is necessary for creating a roslaunch file for https://github.com/maudzung/SFA3D/blob/ea0222c1b35489dc35d8452c989c4b014e20e0da/ros/src/super_fast_object_detection/src/rosInference.py. 
Otherwise, following errors will occur:
```
error: unrecognized arguments: __name:=xxx __log:=xxxx.log
```