### PR TITLE
Fixed protobuf version

### DIFF
--- a/dataset/kitti/classes_names.txt
+++ b/dataset/kitti/classes_names.txt
@@ -1,0 +1,3 @@
+Car
+Pedestrian
+Cyclist

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ easydict==1.9
 opencv-python==4.2.0.34
 numpy==1.18.3
 torchsummary==1.5.1
+protobuf==3.19.6
 tensorboard==2.2.1
 scikit-learn==0.22.2
 wget==3.2


### PR DESCRIPTION
I have set the version of protobuf to 3.19.6. This is the last version that works with Python 3.6.

Best regards,
Aleksandr